### PR TITLE
[fix] - Package version URL error

### DIFF
--- a/i3-gnome/.SRCINFO
+++ b/i3-gnome/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = i3-gnome
 	pkgdesc = Use i3 with GNOME Session integration.
-	pkgver = 3.34.1
+	pkgver = 3.34.0
 	pkgrel = 1
 	epoch = 1
 	url = https://github.com/i3-gnome/i3-gnome/

--- a/i3-gnome/PKGBUILD
+++ b/i3-gnome/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jesús Castro <x51v4n@gmail.com>
 
 pkgname=i3-gnome
-pkgver=3.34.1
+pkgver=3.34.0
 pkgrel=1
 epoch=1
 pkgdesc="Use i3 with GNOME Session integration."


### PR DESCRIPTION
Hi! o/

I'm getting error installing i3-gnome from AUR:
```
==> Making package: i3-gnome 1:3.34.1-1 (seg 21 out 2019 23:59:06 -03)
==> Retrieving sources...
  -> Downloading i3-gnome-3.34.1.zip...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   122    0   122    0     0    227      0 --:--:-- --:--:-- --:--:--   227
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
==> ERROR: Failure while downloading https://github.com/i3-gnome/i3-gnome/archive/3.34.1.zip
    Aborting...
Error downloading sources: i3-gnome
```

The last release in i3-gnome [repo](https://github.com/i3-gnome/i3-gnome/releases) are `3.34.0`, not `3.32.1`.